### PR TITLE
Replace Serilog with Microsoft.Extensions.Logging 

### DIFF
--- a/src/LightControl.Api/LightControl.Api.csproj
+++ b/src/LightControl.Api/LightControl.Api.csproj
@@ -10,14 +10,8 @@
     <ItemGroup>
         <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.0" />
         <PackageReference Include="Swashbuckle.AspNetCore" Version="7.2.0" />
-        <PackageReference Include="Iot.Device.Bindings" Version="3.2.0" />
-        <PackageReference Include="Serilog" Version="4.1.0" />
-        <PackageReference Include="Serilog.AspNetCore" Version="8.0.3" />
-        <PackageReference Include="Serilog.Enrichers.Environment" Version="3.0.1" />
-        <PackageReference Include="Serilog.Enrichers.Thread" Version="4.0.0" />
-        <PackageReference Include="Serilog.Settings.Configuration" Version="8.0.4" />
-        <PackageReference Include="Serilog.Sinks.Console" Version="6.0.0" />
-        <PackageReference Include="Serilog.Sinks.File" Version="6.0.0" />
+                <PackageReference Include="Iot.Device.Bindings" Version="3.2.0" />
+
         <PackageReference Include="System.Device.Gpio" Version="3.2.0" />
     </ItemGroup>
 

--- a/src/LightControl.Api/Program.cs
+++ b/src/LightControl.Api/Program.cs
@@ -9,6 +9,11 @@ public class Program
     public static void Main(string[] args)
     {
         var builder = WebApplication.CreateBuilder(args);
+        
+        // Configure logging
+        builder.Logging.ClearProviders();
+        builder.Logging.AddConsole();
+        
         builder.Services.AddControllers();
         builder.Services.AddSingleton(typeof(ILogger), typeof(Logger<Program>));
         builder.Services.AddEndpointsApiExplorer();

--- a/src/LightControl.Api/appsettings.Development.json
+++ b/src/LightControl.Api/appsettings.Development.json
@@ -1,45 +1,16 @@
 {
-  "Serilog": {
-    "Using": [
-      "Serilog.Sinks.Console"
-    ],
-    "MinimumLevel": "Information",
-    "WriteTo": [
-      {
-        "Name": "Console",
-        "Args": {
-          "theme": "Serilog.Sinks.SystemConsole.Themes.AnsiConsoleTheme::Code, Serilog.Sinks.Console",
-          "outputTemplate": "[{Timestamp:HH:mm:ss} {Level:u3}] {Message:lj} <s:{SourceContext}>{NewLine}{Exception}"
-        }
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    },
+    "Console": {
+      "FormatterName": "simple",
+      "FormatterOptions": {
+        "SingleLine": true,
+        "IncludeScopes": true,
+        "TimestampFormat": "HH:mm:ss "
       }
-    ],
-    "Enrich": [
-      "FromLogContext",
-      "WithMachineName",
-      "WithThreadId"
-    ],
-    "Destructure": [
-      {
-        "Name": "ToMaximumDepth",
-        "Args": {
-          "maximumDestructuringDepth": 4
-        }
-      },
-      {
-        "Name": "ToMaximumStringLength",
-        "Args": {
-          "maximumStringLength": 100
-        }
-      },
-      {
-        "Name": "ToMaximumCollectionCount",
-        "Args": {
-          "maximumCollectionCount": 10
-        }
-      }
-    ],
-    "Properties": {
-      "Application": "Lego Light Controller"
     }
   },
   "HardwareOptions": {

--- a/src/LightControl.Api/appsettings.json
+++ b/src/LightControl.Api/appsettings.json
@@ -1,48 +1,9 @@
 {
   "AllowedHosts": "*",
-  "Serilog": {
-    "Using": [
-      "Serilog.Sinks.File"
-    ],
-    "MinimumLevel": "Information",
-    "WriteTo": [
-      {
-        "Name": "File",
-        "Args": {
-          "path": "/var/log/light-ctl/daily-.log",
-          "rollingInterval": "Day",
-          "retainedFileCountLimit": 7,
-          "formatter": "Serilog.Formatting.Compact.CompactJsonFormatter, Serilog.Formatting.Compact"
-        }
-      }
-    ],
-    "Enrich": [
-      "FromLogContext",
-      "WithMachineName",
-      "WithThreadId"
-    ],
-    "Destructure": [
-      {
-        "Name": "ToMaximumDepth",
-        "Args": {
-          "maximumDestructuringDepth": 4
-        }
-      },
-      {
-        "Name": "ToMaximumStringLength",
-        "Args": {
-          "maximumStringLength": 100
-        }
-      },
-      {
-        "Name": "ToMaximumCollectionCount",
-        "Args": {
-          "maximumCollectionCount": 10
-        }
-      }
-    ],
-    "Properties": {
-      "Application": "Lego Light Controller"
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
     }
   },
   "HardwareOptions": {


### PR DESCRIPTION
- Remove all Serilog packages and dependencies 
- Replace Serilog configuration with standard ASP.NET Core logging 
- Configure console logging with custom formatting 
- All existing ILogger<T> usage continues to work unchanged 
- Tests pass successfully